### PR TITLE
Fixed wrong reference to config in constructor

### DIFF
--- a/src/configry.js
+++ b/src/configry.js
@@ -26,7 +26,7 @@ function Configry (defaultConfig, persistent) {
   // using localStorage
   var conf = JSON.parse(localStorage.getItem('config'));
   if (conf) {
-    for (i in this.conf) {
+    for (i in conf) {
       this.config[i] = conf[i];
     }
   }


### PR DESCRIPTION
config is declared as a var and its not a member of the object.
